### PR TITLE
지도 뷰 구현 중간 커밋

### DIFF
--- a/Finiens/Finiens.xcodeproj/project.pbxproj
+++ b/Finiens/Finiens.xcodeproj/project.pbxproj
@@ -26,6 +26,8 @@
 		702BB3C72A716CAE00610C65 /* RootStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 702BB3C62A716CAE00610C65 /* RootStore.swift */; };
 		702BB3C92A716D4F00610C65 /* RootView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 702BB3C82A716D4F00610C65 /* RootView.swift */; };
 		93524B132A7B3DD100BF3F53 /* NMapsMap in Frameworks */ = {isa = PBXBuildFile; productRef = 93524B122A7B3DD100BF3F53 /* NMapsMap */; };
+		93524B342A7B8CD100BF3F53 /* LocationSearchStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93524B332A7B8CD100BF3F53 /* LocationSearchStore.swift */; };
+		93524B362A7BFE7E00BF3F53 /* SearchBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93524B352A7BFE7E00BF3F53 /* SearchBar.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -66,6 +68,8 @@
 		702BB3C42A7167F900610C65 /* SearchMapView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchMapView.swift; sourceTree = "<group>"; };
 		702BB3C62A716CAE00610C65 /* RootStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RootStore.swift; sourceTree = "<group>"; };
 		702BB3C82A716D4F00610C65 /* RootView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RootView.swift; sourceTree = "<group>"; };
+		93524B332A7B8CD100BF3F53 /* LocationSearchStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocationSearchStore.swift; sourceTree = "<group>"; };
+		93524B352A7BFE7E00BF3F53 /* SearchBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchBar.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -229,8 +233,18 @@
 			children = (
 				702BB3C42A7167F900610C65 /* SearchMapView.swift */,
 				702BB3C22A7167EE00610C65 /* SearchMapStore.swift */,
+				93524B352A7BFE7E00BF3F53 /* SearchBar.swift */,
+				93524B322A7B8CB300BF3F53 /* LocationSearch */,
 			);
 			path = SearchMap;
+			sourceTree = "<group>";
+		};
+		93524B322A7B8CB300BF3F53 /* LocationSearch */ = {
+			isa = PBXGroup;
+			children = (
+				93524B332A7B8CD100BF3F53 /* LocationSearchStore.swift */,
+			);
+			path = LocationSearch;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -378,11 +392,13 @@
 				702BB3782A7163F900610C65 /* RootApp.swift in Sources */,
 				702BB3B22A7165C900610C65 /* MainTabStore.swift in Sources */,
 				702BB3C32A7167EE00610C65 /* SearchMapStore.swift in Sources */,
+				93524B362A7BFE7E00BF3F53 /* SearchBar.swift in Sources */,
 				702BB3B92A71676700610C65 /* HomeView.swift in Sources */,
 				702BB3C92A716D4F00610C65 /* RootView.swift in Sources */,
 				702BB3B72A7166AB00610C65 /* HomeStore.swift in Sources */,
 				702BB3B02A7165BC00610C65 /* MainTabView.swift in Sources */,
 				702BB3C52A7167F900610C65 /* SearchMapView.swift in Sources */,
+				93524B342A7B8CD100BF3F53 /* LocationSearchStore.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Finiens/Finiens.xcodeproj/project.pbxproj
+++ b/Finiens/Finiens.xcodeproj/project.pbxproj
@@ -25,6 +25,7 @@
 		702BB3C52A7167F900610C65 /* SearchMapView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 702BB3C42A7167F900610C65 /* SearchMapView.swift */; };
 		702BB3C72A716CAE00610C65 /* RootStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 702BB3C62A716CAE00610C65 /* RootStore.swift */; };
 		702BB3C92A716D4F00610C65 /* RootView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 702BB3C82A716D4F00610C65 /* RootView.swift */; };
+		70AB913B2A7CBF7B00ECE03C /* LocationSearchView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70AB913A2A7CBF7B00ECE03C /* LocationSearchView.swift */; };
 		93524B132A7B3DD100BF3F53 /* NMapsMap in Frameworks */ = {isa = PBXBuildFile; productRef = 93524B122A7B3DD100BF3F53 /* NMapsMap */; };
 		93524B342A7B8CD100BF3F53 /* LocationSearchStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93524B332A7B8CD100BF3F53 /* LocationSearchStore.swift */; };
 		93524B362A7BFE7E00BF3F53 /* SearchBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93524B352A7BFE7E00BF3F53 /* SearchBar.swift */; };
@@ -68,6 +69,7 @@
 		702BB3C42A7167F900610C65 /* SearchMapView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchMapView.swift; sourceTree = "<group>"; };
 		702BB3C62A716CAE00610C65 /* RootStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RootStore.swift; sourceTree = "<group>"; };
 		702BB3C82A716D4F00610C65 /* RootView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RootView.swift; sourceTree = "<group>"; };
+		70AB913A2A7CBF7B00ECE03C /* LocationSearchView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocationSearchView.swift; sourceTree = "<group>"; };
 		93524B332A7B8CD100BF3F53 /* LocationSearchStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocationSearchStore.swift; sourceTree = "<group>"; };
 		93524B352A7BFE7E00BF3F53 /* SearchBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchBar.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -243,6 +245,7 @@
 			isa = PBXGroup;
 			children = (
 				93524B332A7B8CD100BF3F53 /* LocationSearchStore.swift */,
+				70AB913A2A7CBF7B00ECE03C /* LocationSearchView.swift */,
 			);
 			path = LocationSearch;
 			sourceTree = "<group>";
@@ -395,6 +398,7 @@
 				93524B362A7BFE7E00BF3F53 /* SearchBar.swift in Sources */,
 				702BB3B92A71676700610C65 /* HomeView.swift in Sources */,
 				702BB3C92A716D4F00610C65 /* RootView.swift in Sources */,
+				70AB913B2A7CBF7B00ECE03C /* LocationSearchView.swift in Sources */,
 				702BB3B72A7166AB00610C65 /* HomeStore.swift in Sources */,
 				702BB3B02A7165BC00610C65 /* MainTabView.swift in Sources */,
 				702BB3C52A7167F900610C65 /* SearchMapView.swift in Sources */,

--- a/Finiens/Finiens/Feature/SearchMap/LocationSearch/LocationSearchStore.swift
+++ b/Finiens/Finiens/Feature/SearchMap/LocationSearch/LocationSearchStore.swift
@@ -1,28 +1,30 @@
 //
-//  SearchMapStore.swift
+//  LocationSearchStore.swift
 //  Finiens
 //
-//  Created by 송영모 on 2023/07/26.
+//  Created by 이소리 on 2023/08/03.
 //
 
 import ComposableArchitecture
 
-struct SearchMapStore: ReducerProtocol {
+struct LocationSearchStore: ReducerProtocol {
     struct State: Equatable {
-        var isShowingLocationSearchView: Bool = false
+        var address: String = ""
     }
     
     enum Action: Equatable {
-        case isTappedLocationSearchBar
+        case updateAddress(String)
     }
     
     var body: some ReducerProtocol<State, Action> {
         Reduce { state, action in
             switch action {
-            case .isTappedLocationSearchBar:
-                state.isShowingLocationSearchView.toggle()
+            case .updateAddress(address):
+                state.address =  address
                 return .none
             }
         }
     }
 }
+
+

--- a/Finiens/Finiens/Feature/SearchMap/LocationSearch/LocationSearchStore.swift
+++ b/Finiens/Finiens/Feature/SearchMap/LocationSearch/LocationSearchStore.swift
@@ -19,8 +19,8 @@ struct LocationSearchStore: ReducerProtocol {
     var body: some ReducerProtocol<State, Action> {
         Reduce { state, action in
             switch action {
-            case .updateAddress(address):
-                state.address =  address
+            case let .updateAddress(address):
+                state.address = address
                 return .none
             }
         }

--- a/Finiens/Finiens/Feature/SearchMap/LocationSearch/LocationSearchView.swift
+++ b/Finiens/Finiens/Feature/SearchMap/LocationSearch/LocationSearchView.swift
@@ -1,0 +1,42 @@
+//
+//  LocationSearchView.swift
+//  Finiens
+//
+//  Created by 송영모 on 2023/08/04.
+//
+
+import SwiftUI
+
+import ComposableArchitecture
+
+struct LocationSearchView: View {
+    @Environment(\.presentationMode) var presentationMode
+    @State var address: String = ""
+    let store: StoreOf<LocationSearchStore>
+    
+    init(store: StoreOf<LocationSearchStore>) {
+        self.store = store
+    }
+    
+    var body: some View {
+        VStack {
+            NavigationView {
+                VStack {
+                    SearchBar(address: $address)
+                }
+                    .navigationBarTitle("장소 검색")
+                    .toolbar {
+                        ToolbarItem {
+                            Button(action: {
+                                presentationMode.wrappedValue.dismiss()
+                            }) {
+                                Text("닫기")
+                                    .foregroundColor(Color(.red))
+                            }
+                        }
+                    }
+            }
+        }
+        .padding()
+    }
+}

--- a/Finiens/Finiens/Feature/SearchMap/LocationSearch/LocationSearchView.swift
+++ b/Finiens/Finiens/Feature/SearchMap/LocationSearch/LocationSearchView.swift
@@ -12,6 +12,7 @@ import ComposableArchitecture
 struct LocationSearchView: View {
     @Environment(\.presentationMode) var presentationMode
     @State var address: String = ""
+    
     let store: StoreOf<LocationSearchStore>
     
     init(store: StoreOf<LocationSearchStore>) {
@@ -19,22 +20,24 @@ struct LocationSearchView: View {
     }
     
     var body: some View {
-        VStack {
-            NavigationView {
-                VStack {
-                    SearchBar(address: $address)
-                }
-                    .navigationBarTitle("장소 검색")
-                    .toolbar {
-                        ToolbarItem {
-                            Button(action: {
-                                presentationMode.wrappedValue.dismiss()
-                            }) {
-                                Text("닫기")
-                                    .foregroundColor(Color(.red))
+        WithViewStore(self.store) { viewStore in
+            VStack {
+                NavigationView {
+                    VStack {
+                        SearchBar(address: $address)
+                    }
+                        .navigationBarTitle("장소 검색")
+                        .toolbar {
+                            ToolbarItem {
+                                Button(action: {
+                                    presentationMode.wrappedValue.dismiss() // dismiss()가 활성화 되지 않음
+                                }) {
+                                    Text("닫기")
+                                        .foregroundColor(Color(.red))
+                                }
                             }
                         }
-                    }
+                }
             }
         }
         .padding()

--- a/Finiens/Finiens/Feature/SearchMap/SearchBar.swift
+++ b/Finiens/Finiens/Feature/SearchMap/SearchBar.swift
@@ -1,0 +1,41 @@
+//
+//  SearchBar.swift
+//  Finiens
+//
+//  Created by 이소리 on 2023/08/04.
+//
+
+import SwiftUI
+
+struct SearchBar: View {
+    
+    @Binding var address: String
+
+    var body: some View {
+        HStack {
+            HStack {
+                TextField("장소 검색", text: $address)
+                    .foregroundColor(.primary)
+
+                if !address.isEmpty {
+                    Button(action: {
+                        self.address = ""
+                    }) {
+                        Image(systemName: "xmark.circle.fill")
+                            .foregroundColor(.gray)
+                    }
+                } else {
+                    EmptyView()
+                }
+            }
+            .accentColor(.red)
+            .foregroundColor(.black)
+            .padding()
+            .frame(width: 361, height: 34)
+            .background(Color(.systemGray6))
+            .cornerRadius(10)
+
+        }
+        .padding(.horizontal)
+    }
+}

--- a/Finiens/Finiens/Feature/SearchMap/SearchMapStore.swift
+++ b/Finiens/Finiens/Feature/SearchMap/SearchMapStore.swift
@@ -10,10 +10,14 @@ import ComposableArchitecture
 struct SearchMapStore: ReducerProtocol {
     struct State: Equatable {
         var isShowingLocationSearchView: Bool = false
+        
+        var locationSearch: LocationSearchStore.State = .init()
     }
     
     enum Action: Equatable {
         case isTappedLocationSearchBar
+        
+        case locationSearch(LocationSearchStore.Action)
     }
     
     var body: some ReducerProtocol<State, Action> {
@@ -21,6 +25,9 @@ struct SearchMapStore: ReducerProtocol {
             switch action {
             case .isTappedLocationSearchBar:
                 state.isShowingLocationSearchView.toggle()
+                return .none
+                
+            default:
                 return .none
             }
         }

--- a/Finiens/Finiens/Feature/SearchMap/SearchMapView.swift
+++ b/Finiens/Finiens/Feature/SearchMap/SearchMapView.swift
@@ -6,16 +6,154 @@
 //
 
 import SwiftUI
-
 import ComposableArchitecture
+import NMapsMap
 
 struct SearchMapView: View {
     let store: StoreOf<SearchMapStore>
     
+    let mapView = NMFMapView()
+    
     var body: some View {
-        Text("지도 뷰 입니다.")
+        @State var region: (Double, Double) = (37.55037, 127.07435)
+        
+        @State var isShowingLocationSearchView: Bool = false
+
+
+        WithViewStore(store) { viewStore in
+            ZStack {
+                UIMapView()
+                    .edgesIgnoringSafeArea(.vertical)
+
+                VStack {
+                    HStack {
+                        Button(action: {
+                            viewStore.send(.isTappedLocationSearchBar)
+                        }) {
+                            Text("장소 검색")
+                                .foregroundColor(Color(.gray))
+                        }
+                        Spacer()
+                        Image(systemName: "magnifyingglass")
+                    }
+                    .padding()
+                    .frame(width: 353, height: 34)
+                    .background(Color(.white))
+                    .cornerRadius(8)
+                    .fullScreenCover(isPresented: viewStore.binding(get: \.isShowingLocationSearchView, send: SearchMapStore.Action.isTappedLocationSearchBar)) {
+                        LocationSearchView(store: store.scope(state: { $0.address }, action: { .updateAddress($0) }))
+                        // 총 네 가지 오류입니다
+                        
+                        // 두 번째 store - Argument passed to call that takes no arguments
+                        // scope - Generic parameter 'ChildAction' could not be inferred
+                        // address - Type 'SearchMapStore.Action' has no member 'updateAddress' -> SearchMapStore을 LocationSearchStore로 바꾸자니 따라붙은 isTappedLocationSearchBar 때문에 어느 것을 수정해야 할지 모르겠어요..
+                        // updateAddress($0) - Value of type 'SearchMapStore.State' has no member 'address' -> 위와 같습니다
+                        
+                        // searchMapStore - isShowingLocationSearchView, isTappedLocationSearchBar 포함
+                        // LocationSearchStore - address, updateAddress 포함
+                    }
+                    Spacer()
+                    
+                    VStack {
+                        HStack {
+                            Button(action: {
+                                print("지도 화면 확대")
+                            }, label: {
+                                Image(systemName: "plus")
+                            })
+                            .font(Font.title.weight(.bold))
+                            .frame(width: 40, height: 40)
+                            .foregroundColor(Color(.red))
+                            .background(Color.white)
+                            .clipShape(Circle())
+                            
+                            Spacer()
+                            
+                            Button(action: {
+                                print("길찾기")
+                            }, label: {
+                                Image(systemName: "arrow.triangle.turn.up.right.circle.fill")
+                                    .resizable()
+                                    .frame(width: 40, height: 40)
+                            })
+                            .foregroundColor(Color(.red))
+                            .background(Color.white)
+                            .clipShape(Circle())
+                        }
+                        HStack {
+                            Button(action: {
+                                print("지도 화면 축소")
+                            }, label: {
+                                Image(systemName: "minus")
+                            })
+                            .font(Font.title.weight(.bold))
+                            .frame(width: 40, height: 40)
+                            .foregroundColor(Color(.red))
+                            .background(Color.white)
+                            .clipShape(Circle())
+                            
+                            Spacer()
+                            
+                            Button(action: {
+                                print("현재 내 위치로 이동")
+                            }, label: {
+                                Image(systemName: "scope")
+                            })
+                            .font(Font.title.weight(.bold))
+                            .frame(width: 40, height: 40)
+                            .foregroundColor(Color(.red))
+                            .background(Color.white)
+                            .clipShape(Circle())
+                        }
+                    }
+                }
+                .padding()
+            .background(Color(.black))
+            }
+        }
     }
 }
+
+struct UIMapView: UIViewRepresentable {
+    func makeUIView(context: Context) -> NMFNaverMapView {
+        let view = NMFNaverMapView()
+        view.showZoomControls = false
+        view.mapView.positionMode = .direction
+        view.mapView.zoomLevel = 17
+      
+        return view
+    }
+    
+    func updateUIView(_ uiView: NMFNaverMapView, context: Context) {}
+}
+
+struct LocationSearchView: View {
+    @Environment(\.presentationMode) var presentationMode
+    @State var address: String = ""
+    
+    var body: some View {
+        VStack {
+            NavigationView {
+                VStack {
+                    SearchBar(address: $address)
+                }
+                    .navigationBarTitle("장소 검색")
+                    .toolbar {
+                        ToolbarItem {
+                            Button(action: {
+                                presentationMode.wrappedValue.dismiss()
+                            }) {
+                                Text("닫기")
+                                    .foregroundColor(Color(.red))
+                            }
+                        }
+                    }
+            }
+        }
+        .padding()
+    }
+}
+
 
 struct SearchMapView_Previews: PreviewProvider {
     static var previews: some View {

--- a/Finiens/Finiens/Feature/SearchMap/SearchMapView.swift
+++ b/Finiens/Finiens/Feature/SearchMap/SearchMapView.swift
@@ -9,21 +9,29 @@ import SwiftUI
 import ComposableArchitecture
 import NMapsMap
 
+struct NaverMapUIView: UIViewRepresentable {
+    func makeUIView(context: Context) -> NMFMapView {
+        return NMFMapView(frame: .zero)
+    }
+
+    func updateUIView(_ uiView: NMFMapView, context: Context) {
+        let center = NMGLatLng(lat: 37.5666102, lng: 126.9783881)
+        uiView.moveCamera(NMFCameraUpdate(scrollTo: center))
+    }
+}
+
 struct SearchMapView: View {
     let store: StoreOf<SearchMapStore>
-    
-    let mapView = NMFMapView()
-    
+
     var body: some View {
-        @State var region: (Double, Double) = (37.55037, 127.07435)
-        
         @State var isShowingLocationSearchView: Bool = false
+        @State var region = NMFCameraPosition(NMGLatLng(lat: 37.54330366, lng: 127.04455548), zoom: 15, tilt: 0, heading: 0)
 
 
         WithViewStore(store) { viewStore in
             ZStack {
-                UIMapView()
-                    .edgesIgnoringSafeArea(.vertical)
+                NaverMapUIView()
+                    .edgesIgnoringSafeArea(.top)
 
                 VStack {
                     HStack {
@@ -43,15 +51,6 @@ struct SearchMapView: View {
                     .fullScreenCover(isPresented: viewStore.binding(get: \.isShowingLocationSearchView, send: SearchMapStore.Action.isTappedLocationSearchBar)) {
                         
                         LocationSearchView(store: self.store.scope(state: \.locationSearch, action: SearchMapStore.Action.locationSearch))
-                        // 총 네 가지 오류입니다
-                        
-                        // 두 번째 store - Argument passed to call that takes no arguments
-                        // scope - Generic parameter 'ChildAction' could not be inferred
-                        // address - Type 'SearchMapStore.Action' has no member 'updateAddress' -> SearchMapStore을 LocationSearchStore로 바꾸자니 따라붙은 isTappedLocationSearchBar 때문에 어느 것을 수정해야 할지 모르겠어요..
-                        // updateAddress($0) - Value of type 'SearchMapStore.State' has no member 'address' -> 위와 같습니다
-                        
-                        // searchMapStore - isShowingLocationSearchView, isTappedLocationSearchBar 포함
-                        // LocationSearchStore - address, updateAddress 포함
                     }
                     Spacer()
                     
@@ -81,6 +80,8 @@ struct SearchMapView: View {
                             .background(Color.white)
                             .clipShape(Circle())
                         }
+                        .padding(.vertical, 5.0)
+
                         HStack {
                             Button(action: {
                                 print("지도 화면 축소")
@@ -106,10 +107,13 @@ struct SearchMapView: View {
                             .background(Color.white)
                             .clipShape(Circle())
                         }
+                        .padding(.vertical, 5.0)
+
                     }
+                    .padding(.vertical)
+
                 }
                 .padding()
-            .background(Color(.black))
             }
         }
     }

--- a/Finiens/Finiens/Feature/SearchMap/SearchMapView.swift
+++ b/Finiens/Finiens/Feature/SearchMap/SearchMapView.swift
@@ -41,7 +41,8 @@ struct SearchMapView: View {
                     .background(Color(.white))
                     .cornerRadius(8)
                     .fullScreenCover(isPresented: viewStore.binding(get: \.isShowingLocationSearchView, send: SearchMapStore.Action.isTappedLocationSearchBar)) {
-                        LocationSearchView(store: store.scope(state: { $0.address }, action: { .updateAddress($0) }))
+                        
+                        LocationSearchView(store: self.store.scope(state: \.locationSearch, action: SearchMapStore.Action.locationSearch))
                         // 총 네 가지 오류입니다
                         
                         // 두 번째 store - Argument passed to call that takes no arguments
@@ -126,34 +127,6 @@ struct UIMapView: UIViewRepresentable {
     
     func updateUIView(_ uiView: NMFNaverMapView, context: Context) {}
 }
-
-struct LocationSearchView: View {
-    @Environment(\.presentationMode) var presentationMode
-    @State var address: String = ""
-    
-    var body: some View {
-        VStack {
-            NavigationView {
-                VStack {
-                    SearchBar(address: $address)
-                }
-                    .navigationBarTitle("장소 검색")
-                    .toolbar {
-                        ToolbarItem {
-                            Button(action: {
-                                presentationMode.wrappedValue.dismiss()
-                            }) {
-                                Text("닫기")
-                                    .foregroundColor(Color(.red))
-                            }
-                        }
-                    }
-            }
-        }
-        .padding()
-    }
-}
-
 
 struct SearchMapView_Previews: PreviewProvider {
     static var previews: some View {


### PR DESCRIPTION
## PR 요약
<!-- 해당 pr에서 작업한 내역을 적어주세요. -->
NMapsMap 패키지를 이용해서 지도 화면을 추가하였고, 기본 지도 뷰 ui를 구현하였습니다. (버튼의 기능들은 아직 구현하지 못했습니다)
장소 검색 바를 탭 했을 때 화면이 전환되도록 하였고, 전환된 화면 ui를 조금 구현하였습니다.(휘선 오빠에게 넘겨주기 위해 이 이상은 건들지 않을게요!)

#### 📌 변경 사항
<!-- 변경사항 및 주의 사항 (모듈 설치 등)을 적어주세요. -->
위의 과정 중에 오류가 나서 중간 pr을 올리게 되었습니다.

##### ✅ PR check list
<!-- 피드백 받고 싶거나, 공유할 사항을 적어주세요 -->
총 네 가지 오류입니다. (코드에 주석 달아놓았어요!)

1. 두 번째 store - Argument passed to call that takes no arguments
2. scope - Generic parameter 'ChildAction' could not be inferred 
3. address - Type 'SearchMapStore.Action' has no member 'updateAddress' -> SearchMapStore을 LocationSearchStore로 바꾸자니 따라붙은 isTappedLocationSearchBar 때문에 어느 것을 수정해야 할지 모르겠어요.. 
4. updateAddress($0) - Value of type 'SearchMapStore.State' has no member 'address' -> 위와 같습니다 

아래는 분리된 파일에 포함된 내용들입니다. 볼 때 편하실까하여 적어보았어요!

searchMapStore - isShowingLocationSearchView, isTappedLocationSearchBar 포함
LocationSearchStore - address, updateAddress 포함

#### Linked Issue
<!-- 해결한 이슈 넘버를 붙여주세요. -->
close #


<!-- PR 요청 전 마지막 확인!
- commit message가 적절한지 확인해주세요. 
- 마지막으로 Coding Convention을 준수했는지 확인해주세요.
- 적절한 branch로 요청했는지 확인해주세요.
- Assignees, Label을 붙여주세요.
- 해결한 이슈를 Link 해주세요.
- PR이 승인된 경우 해당 브랜치는 삭제해주세요.
-->