### PR TITLE
[Feat/#45] widget setting & 사소한 변경 사항

### DIFF
--- a/Targets/Finiens/Sources/Feature/SearchMap/Button/ButtonStyle.swift
+++ b/Targets/Finiens/Sources/Feature/SearchMap/Button/ButtonStyle.swift
@@ -17,8 +17,8 @@ struct CircleButton: View {
             Image(systemName: image)
                 .font(Font.title.weight(.bold))
                 .frame(width: 40, height: 40)
-                .foregroundColor(Color(.red))
-                .background(Color.white)
+                .foregroundColor(Color.keyColor)
+                .background(Color.shapeColor)
                 .clipShape(Circle())
         }
     }

--- a/Targets/Finiens/Sources/Feature/SearchMap/LocationSearch/LocationSearchView.swift
+++ b/Targets/Finiens/Sources/Feature/SearchMap/LocationSearch/LocationSearchView.swift
@@ -33,7 +33,7 @@ struct LocationSearchView: View {
                                     presentationMode.wrappedValue.dismiss() // dismiss()가 활성화 되지 않음
                                 }) {
                                     Text("닫기")
-                                        .foregroundColor(Color(.red))
+                                        .foregroundColor(Color.keyColor)
                                 }
                             }
                         }

--- a/Targets/Finiens/Sources/Feature/SearchMap/SearchBar/ArrivalSearchBar.swift
+++ b/Targets/Finiens/Sources/Feature/SearchMap/SearchBar/ArrivalSearchBar.swift
@@ -20,7 +20,7 @@ struct ArrivalSearchBar: View {
                     self.arrival = ""
                 }) {
                     Image(systemName: "xmark.circle.fill")
-                        .foregroundColor(.gray)
+                        .foregroundColor(.shapeQuaternaryColor)
                 }
             } else {
                 EmptyView()
@@ -28,9 +28,9 @@ struct ArrivalSearchBar: View {
         }
         .padding()
         .frame(width: 292, height: 34)
-        .background(Color(uiColor: .secondarySystemBackground))
-        .accentColor(.red)
-        .foregroundColor(.black)
+        .background(Color.shapeSecondaryColor)
+        .accentColor(.keyColor)
+        .foregroundColor(.textQuaternaryColor)
         .cornerRadius(10)
     }
 }

--- a/Targets/Finiens/Sources/Feature/SearchMap/SearchBar/DepArrBar.swift
+++ b/Targets/Finiens/Sources/Feature/SearchMap/SearchBar/DepArrBar.swift
@@ -1,140 +1,47 @@
 //
-//  routeLiveActivity.swift
-//  route
+//  DepArrBar.swift
+//  Finiens
 //
-//  Created by 이소리 on 2023/08/24.
+//  Created by 이소리 on 2023/08/15.
+//  Copyright © 2023 alom.com. All rights reserved.
 //
 
-import ActivityKit
-import WidgetKit
 import SwiftUI
 
-struct routeAttributes: ActivityAttributes {
-    public struct ContentState: Codable, Hashable {
-        // Dynamic stateful properties about your activity go here!
-        var value: Int
+struct DepArrBar: View {
+    @State var departure: String = ""
+    @State var arrival: String = ""
+
+    func swapDepartureArrival() {
+        withAnimation {
+            let tmp = departure
+            departure = arrival
+            arrival = tmp
+        }
     }
-
-    // Fixed non-changing properties about your activity go here!
-    var name: String
     
-}
-
-struct routeLiveActivity: Widget {
-    @State private var progressValue: Double = 85.0 // 1~99
-    let totalValue: Double = 100.0
-    
-    var body: some WidgetConfiguration {
-        ActivityConfiguration(for: routeAttributes.self) { context in
-            // Lock screen/banner UI goes here
+    var body: some View {
+        HStack {
             VStack {
-                Text("view")
+                DepartureSearchBar(departure: $departure)
+                ArrivalSearchBar(arrival: $arrival)
             }
-            .activityBackgroundTint(Color.cyan)
-            .activitySystemActionForegroundColor(Color.black)
-
-        } dynamicIsland: { context in
-            DynamicIsland {
-                // Expanded UI goes here.  Compose the expanded UI through
-                // various regions, like leading/trailing/center/bottom
-                DynamicIslandExpandedRegion(.leading) {
-                    Text("21:59 도착")
-                        .font(.headline)
-                }
-                DynamicIslandExpandedRegion(.trailing) {
-                    Text("18분 남음")
-                        .font(.headline)
-                }
-                DynamicIslandExpandedRegion(.bottom) {
-                    VStack(spacing: 0) {
-                        HStack(alignment: .top) {
-                            Image(systemName: "tram")
-                            
-                            Spacer()
-                            
-                            VStack(alignment: .leading) {
-                                HStack {
-                                    Text("어린이대공원역 승차")
-                                        .fontWeight(.bold)
-                                    
-                                    Text("석남(거북시장) 방면")
-                                        .foregroundColor(Color.gray)
-                                        .font(.system(size: 15))
-                                    
-                                    Spacer()
-                                }
-                                Text("빠른환승 1-1")
-                                    .foregroundColor(Color.gray)
-                                    .font(.system(size: 15))
-                                
-                                HStack {
-                                    Text("2분")
-                                        .font(.system(size: 15))
-                                        .foregroundColor(Color.gray)
-                                    
-                                    Text("1개역 이동")
-                                        .fontWeight(.bold)
-                                        .font(.system(size: 15))
-                                }
-                            }
-                        }
-                        ProgressView(value: progressValue, total: totalValue)
-                            .progressViewStyle(humanProgressViewStyle(value: $progressValue, total: .constant(totalValue)))
-                    }
-                    .padding(1.0)
-                }
-            } compactLeading: {
-                Image(systemName:"tram.fill")
-            } compactTrailing: {
-                Text("18분 남음")
-            } minimal: {
-                Text("Min")
+            Button(action: {
+                swapDepartureArrival()
+            }) {
+                Image(systemName: "arrow.up.arrow.down")
+                    .foregroundColor(Color(.red))
             }
-            .widgetURL(URL(string: "http://www.apple.com"))
-            .keylineTint(Color.red)
         }
+        .padding()
+        .frame(width: 353, height: 104)
+        .background(Color(.white))
+        .cornerRadius(20)
     }
 }
 
-struct humanProgressViewStyle: ProgressViewStyle {
-    @Binding var value: Double
-    @Binding var total: Double
-    
-    func makeBody(configuration: Configuration) -> some View {
-        
-        let offset = CGFloat(value) / 100
-        return GeometryReader{ geometry in
-            VStack(spacing: 0) {
-                HStack{
-                    Image(systemName: "figure.walk")
-                        .font(.system(size: 15))
-                        .frame(width: CGFloat((geometry.size.width) * offset + 6), alignment: .bottomTrailing) // 6 : 사람이 발을 딱 내딛는 위치
-                    
-                    Spacer()
-                }
-                ProgressView(configuration)
-                    .accentColor(.red)
-            }
-        }
-    }
-}
-
-struct routeLiveActivity_Previews: PreviewProvider {
-    static let attributes = routeAttributes(name: "Me")
-    static let contentState = routeAttributes.ContentState(value: 3)
-
+struct DepArrBar_Previews: PreviewProvider {
     static var previews: some View {
-        attributes
-            .previewContext(contentState, viewKind: .dynamicIsland(.compact))
-            .previewDisplayName("Island Compact")
-        attributes
-            .previewContext(contentState, viewKind: .dynamicIsland(.expanded))
-            .previewDisplayName("Island Expanded")
-        attributes
-            .previewContext(contentState, viewKind: .dynamicIsland(.minimal))
-            .previewDisplayName("Minimal")
-        attributes
-            .previewContext(contentState, viewKind: .content)
-            .previewDisplayName("Notification")
+        DepArrBar()
     }
 }

--- a/Targets/Finiens/Sources/Feature/SearchMap/SearchBar/DepArrBar.swift
+++ b/Targets/Finiens/Sources/Feature/SearchMap/SearchBar/DepArrBar.swift
@@ -30,12 +30,12 @@ struct DepArrBar: View {
                 swapDepartureArrival()
             }) {
                 Image(systemName: "arrow.up.arrow.down")
-                    .foregroundColor(Color(.red))
+                    .foregroundColor(Color.keyColor)
             }
         }
         .padding()
         .frame(width: 353, height: 104)
-        .background(Color(.white))
+        .background(Color.shapeColor)
         .cornerRadius(20)
     }
 }

--- a/Targets/Finiens/Sources/Feature/SearchMap/SearchBar/DepArrBar.swift
+++ b/Targets/Finiens/Sources/Feature/SearchMap/SearchBar/DepArrBar.swift
@@ -1,47 +1,140 @@
 //
-//  DepArrBar.swift
-//  Finiens
+//  routeLiveActivity.swift
+//  route
 //
-//  Created by 이소리 on 2023/08/15.
-//  Copyright © 2023 alom.com. All rights reserved.
+//  Created by 이소리 on 2023/08/24.
 //
 
+import ActivityKit
+import WidgetKit
 import SwiftUI
 
-struct DepArrBar: View {
-    @State var departure: String = ""
-    @State var arrival: String = ""
-
-    func swapDepartureArrival() {
-        withAnimation {
-            let tmp = departure
-            departure = arrival
-            arrival = tmp
-        }
+struct routeAttributes: ActivityAttributes {
+    public struct ContentState: Codable, Hashable {
+        // Dynamic stateful properties about your activity go here!
+        var value: Int
     }
+
+    // Fixed non-changing properties about your activity go here!
+    var name: String
     
-    var body: some View {
-        HStack {
+}
+
+struct routeLiveActivity: Widget {
+    @State private var progressValue: Double = 85.0 // 1~99
+    let totalValue: Double = 100.0
+    
+    var body: some WidgetConfiguration {
+        ActivityConfiguration(for: routeAttributes.self) { context in
+            // Lock screen/banner UI goes here
             VStack {
-                DepartureSearchBar(departure: $departure)
-                ArrivalSearchBar(arrival: $arrival)
+                Text("view")
             }
-            Button(action: {
-                swapDepartureArrival()
-            }) {
-                Image(systemName: "arrow.up.arrow.down")
-                    .foregroundColor(Color(.red))
+            .activityBackgroundTint(Color.cyan)
+            .activitySystemActionForegroundColor(Color.black)
+
+        } dynamicIsland: { context in
+            DynamicIsland {
+                // Expanded UI goes here.  Compose the expanded UI through
+                // various regions, like leading/trailing/center/bottom
+                DynamicIslandExpandedRegion(.leading) {
+                    Text("21:59 도착")
+                        .font(.headline)
+                }
+                DynamicIslandExpandedRegion(.trailing) {
+                    Text("18분 남음")
+                        .font(.headline)
+                }
+                DynamicIslandExpandedRegion(.bottom) {
+                    VStack(spacing: 0) {
+                        HStack(alignment: .top) {
+                            Image(systemName: "tram")
+                            
+                            Spacer()
+                            
+                            VStack(alignment: .leading) {
+                                HStack {
+                                    Text("어린이대공원역 승차")
+                                        .fontWeight(.bold)
+                                    
+                                    Text("석남(거북시장) 방면")
+                                        .foregroundColor(Color.gray)
+                                        .font(.system(size: 15))
+                                    
+                                    Spacer()
+                                }
+                                Text("빠른환승 1-1")
+                                    .foregroundColor(Color.gray)
+                                    .font(.system(size: 15))
+                                
+                                HStack {
+                                    Text("2분")
+                                        .font(.system(size: 15))
+                                        .foregroundColor(Color.gray)
+                                    
+                                    Text("1개역 이동")
+                                        .fontWeight(.bold)
+                                        .font(.system(size: 15))
+                                }
+                            }
+                        }
+                        ProgressView(value: progressValue, total: totalValue)
+                            .progressViewStyle(humanProgressViewStyle(value: $progressValue, total: .constant(totalValue)))
+                    }
+                    .padding(1.0)
+                }
+            } compactLeading: {
+                Image(systemName:"tram.fill")
+            } compactTrailing: {
+                Text("18분 남음")
+            } minimal: {
+                Text("Min")
             }
+            .widgetURL(URL(string: "http://www.apple.com"))
+            .keylineTint(Color.red)
         }
-        .padding()
-        .frame(width: 353, height: 104)
-        .background(Color(.white))
-        .cornerRadius(20)
     }
 }
 
-struct DepArrBar_Previews: PreviewProvider {
+struct humanProgressViewStyle: ProgressViewStyle {
+    @Binding var value: Double
+    @Binding var total: Double
+    
+    func makeBody(configuration: Configuration) -> some View {
+        
+        let offset = CGFloat(value) / 100
+        return GeometryReader{ geometry in
+            VStack(spacing: 0) {
+                HStack{
+                    Image(systemName: "figure.walk")
+                        .font(.system(size: 15))
+                        .frame(width: CGFloat((geometry.size.width) * offset + 6), alignment: .bottomTrailing) // 6 : 사람이 발을 딱 내딛는 위치
+                    
+                    Spacer()
+                }
+                ProgressView(configuration)
+                    .accentColor(.red)
+            }
+        }
+    }
+}
+
+struct routeLiveActivity_Previews: PreviewProvider {
+    static let attributes = routeAttributes(name: "Me")
+    static let contentState = routeAttributes.ContentState(value: 3)
+
     static var previews: some View {
-        DepArrBar()
+        attributes
+            .previewContext(contentState, viewKind: .dynamicIsland(.compact))
+            .previewDisplayName("Island Compact")
+        attributes
+            .previewContext(contentState, viewKind: .dynamicIsland(.expanded))
+            .previewDisplayName("Island Expanded")
+        attributes
+            .previewContext(contentState, viewKind: .dynamicIsland(.minimal))
+            .previewDisplayName("Minimal")
+        attributes
+            .previewContext(contentState, viewKind: .content)
+            .previewDisplayName("Notification")
     }
 }

--- a/Targets/Finiens/Sources/Feature/SearchMap/SearchBar/DepartureSearchBar.swift
+++ b/Targets/Finiens/Sources/Feature/SearchMap/SearchBar/DepartureSearchBar.swift
@@ -20,7 +20,7 @@ struct DepartureSearchBar: View {
                     self.departure = ""
                 }) {
                     Image(systemName: "xmark.circle.fill")
-                        .foregroundColor(.gray)
+                        .foregroundColor(.shapeQuaternaryColor)
                 }
             } else {
                 EmptyView()
@@ -28,9 +28,9 @@ struct DepartureSearchBar: View {
         }
         .padding()
         .frame(width: 292, height: 34)
-        .background(Color(uiColor: .secondarySystemBackground))
-        .accentColor(.red)
-        .foregroundColor(.black)
+        .background(Color.shapeSecondaryColor)
+        .accentColor(.keyColor)
+        .foregroundColor(.textColor)
         .cornerRadius(10)
 
     }

--- a/Targets/Finiens/Sources/Feature/SearchMap/SearchBar/LocationSearchBar.swift
+++ b/Targets/Finiens/Sources/Feature/SearchMap/SearchBar/LocationSearchBar.swift
@@ -22,17 +22,17 @@ struct LocationSearchBar: View {
                         self.address = ""
                     }) {
                         Image(systemName: "xmark.circle.fill")
-                            .foregroundColor(.gray)
+                            .foregroundColor(.shapeQuaternaryColor)
                     }
                 } else {
                     EmptyView()
                 }
             }
-            .accentColor(.red)
-            .foregroundColor(.black)
+            .accentColor(.keyColor)
+            .foregroundColor(.textColor)
             .padding()
             .frame(width: 361, height: 34)
-            .background(Color(.systemGray6))
+            .background(Color.shapeSecondaryColor)
             .cornerRadius(10)
 
         }

--- a/Targets/Finiens/Sources/Feature/SearchMap/SearchBar/SearchBar.swift
+++ b/Targets/Finiens/Sources/Feature/SearchMap/SearchBar/SearchBar.swift
@@ -31,12 +31,11 @@ struct SearchBar: View {
                 .background(Color(.white))
                 .cornerRadius(8)
                 .fullScreenCover(isPresented: viewStore.binding(get: \.isShowingLocationSearchView, send: SearchMapStore.Action.isTappedLocationSearchBar)) {
-                    
                     LocationSearchView(store: self.store.scope(state: \.locationSearch, action: SearchMapStore.Action.locationSearch))
                 }
             }
             else {
-                DepArrBar()
+                DepArrBar();
             }
         }
     }

--- a/Targets/Finiens/Sources/Feature/SearchMap/SearchBar/SearchBar.swift
+++ b/Targets/Finiens/Sources/Feature/SearchMap/SearchBar/SearchBar.swift
@@ -14,7 +14,6 @@ struct SearchBar: View {
 
     var body: some View {
         WithViewStore(self.store, observe: { $0 }) { viewStore in
-            
             // 장소 검색 바
             if viewStore.isDefectedArrowButtonVisible {
                 HStack {
@@ -36,7 +35,6 @@ struct SearchBar: View {
                     LocationSearchView(store: self.store.scope(state: \.locationSearch, action: SearchMapStore.Action.locationSearch))
                 }
             }
-            //출발지-도착지 입력 바
             else {
                 DepArrBar()
             }

--- a/Targets/Finiens/Sources/Feature/SearchMap/SearchBar/SearchBar.swift
+++ b/Targets/Finiens/Sources/Feature/SearchMap/SearchBar/SearchBar.swift
@@ -18,7 +18,7 @@ struct SearchBar: View {
             if viewStore.isDefectedArrowButtonVisible {
                 HStack {
                     Button(action: {
-                        viewStore.send(.isTappedLocationSearchBar)
+                        viewStore.send(.locationSearchBarTapped)
                     }) {
                         Text("장소 검색")
                             .foregroundColor(Color(.gray))
@@ -30,7 +30,7 @@ struct SearchBar: View {
                 .frame(width: 353, height: 34)
                 .background(Color(.white))
                 .cornerRadius(8)
-                .fullScreenCover(isPresented: viewStore.binding(get: \.isShowingLocationSearchView, send: SearchMapStore.Action.isTappedLocationSearchBar)) {
+                .fullScreenCover(isPresented: viewStore.binding(get: \.isShowingLocationSearchView, send: SearchMapStore.Action.locationSearchBarTapped)) {
                     LocationSearchView(store: self.store.scope(state: \.locationSearch, action: SearchMapStore.Action.locationSearch))
                 }
             }

--- a/Targets/Finiens/Sources/Feature/SearchMap/SearchBar/SearchBar.swift
+++ b/Targets/Finiens/Sources/Feature/SearchMap/SearchBar/SearchBar.swift
@@ -21,14 +21,14 @@ struct SearchBar: View {
                         viewStore.send(.locationSearchBarTapped)
                     }) {
                         Text("장소 검색")
-                            .foregroundColor(Color(.gray))
+                            .foregroundColor(Color.textQuaternaryColor)
                     }
                     Spacer()
                     Image(systemName: "magnifyingglass")
                 }
                 .padding()
                 .frame(width: 353, height: 34)
-                .background(Color(.white))
+                .background(Color.shapeColor)
                 .cornerRadius(8)
                 .fullScreenCover(isPresented: viewStore.binding(get: \.isShowingLocationSearchView, send: SearchMapStore.Action.locationSearchBarTapped)) {
                     LocationSearchView(store: self.store.scope(state: \.locationSearch, action: SearchMapStore.Action.locationSearch))

--- a/Targets/Finiens/Sources/Feature/SearchMap/SearchMapStore.swift
+++ b/Targets/Finiens/Sources/Feature/SearchMap/SearchMapStore.swift
@@ -20,10 +20,10 @@ struct SearchMapStore: Reducer {
     
     enum Action: Equatable {
         case locationSearchBarTapped
-        case ZoomInButtonTapped
-        case ZoomOutButtonTapped
-        case ColoredButtonTapped
-        case ScopeButtonTapped
+        case zoomInButtonTapped
+        case zoomOutButtonTapped
+        case coloredButtonTapped
+        case scopeButtonTapped
         
         case locationSearch(LocationSearchStore.Action)
     }
@@ -35,19 +35,19 @@ struct SearchMapStore: Reducer {
                 state.isShowingLocationSearchView.toggle()
                 return .none
                 
-            case .ZoomInButtonTapped:
+            case .zoomInButtonTapped:
                 state.zoomLevel += 0.6
                 return .none
                 
-            case .ZoomOutButtonTapped:
+            case .zoomOutButtonTapped:
                 state.zoomLevel += 0.6
                 return .none
 
-            case .ColoredButtonTapped:
+            case .coloredButtonTapped:
                 state.isDefectedArrowButtonVisible.toggle()
                 return .none
                 
-            case .ScopeButtonTapped:
+            case .scopeButtonTapped:
                 return .none
                 
             default:

--- a/Targets/Finiens/Sources/Feature/SearchMap/SearchMapView.swift
+++ b/Targets/Finiens/Sources/Feature/SearchMap/SearchMapView.swift
@@ -79,14 +79,14 @@ struct SearchMapView: View {
                     viewStore.send(.locationSearchBarTapped)
                 }) {
                     Text("장소 검색")
-                        .foregroundColor(Color(.gray))
+                        .foregroundColor(Color.textQuaternaryColor)
                 }
                 Spacer()
                 
                 Image(systemName: "magnifyingglass")
             }
             .padding()
-            .frameStyle(width: 353, height: 34, backgroundColor: .white, cornerRadius: 8)
+            .frameStyle(width: 353, height: 34, backgroundColor: .shapeColor, cornerRadius: 8)
             .fullScreenCover(isPresented: viewStore.binding(get: \.isShowingLocationSearchView, send: SearchMapStore.Action.locationSearchBarTapped)) {
                 LocationSearchView(store: self.store.scope(state: \.locationSearch, action: SearchMapStore.Action.locationSearch))
             }
@@ -102,11 +102,11 @@ struct SearchMapView: View {
                 swapDepartureArrival()
             }) {
                 Image(systemName: "arrow.up.arrow.down")
-                    .foregroundColor(Color(.red))
+                    .foregroundColor(Color.keyColor)
             }
         }
         .padding()
-        .frameStyle(width: 353, height: 104, backgroundColor: .white, cornerRadius: 20)
+        .frameStyle(width: 353, height: 104, backgroundColor: .shapeColor, cornerRadius: 20)
     }
     
     private func swapDepartureArrival() {

--- a/Targets/Finiens/Sources/Feature/SearchMap/SearchMapView.swift
+++ b/Targets/Finiens/Sources/Feature/SearchMap/SearchMapView.swift
@@ -35,19 +35,19 @@ struct SearchMapView: View {
                     VStack {
                         HStack {
                             CircleButton(image: "plus") {
-                                viewStore.send(.ZoomInButtonTapped)
+                                viewStore.send(.zoomInButtonTapped)
                             }
                             Spacer()
                             
                             VStack {
                                 if viewStore.isDefectedArrowButtonVisible {
                                     CircleButton(image: "arrow.triangle.turn.up.right.circle.fill") {
-                                        viewStore.send(.ColoredButtonTapped)
+                                        viewStore.send(.coloredButtonTapped)
                                     }
                                 }
                                 else {
                                     CircleButton(image: "xmark.circle.fill") {
-                                        viewStore.send(.ColoredButtonTapped)
+                                        viewStore.send(.coloredButtonTapped)
                                     }
                                 }
                             }
@@ -56,12 +56,12 @@ struct SearchMapView: View {
 
                         HStack {
                             CircleButton(image: "minus") {
-                                viewStore.send(.ZoomOutButtonTapped)
+                                viewStore.send(.zoomOutButtonTapped)
                             }
                             Spacer()
                             
                             CircleButton(image: "scope") {
-                                viewStore.send(.ScopeButtonTapped)
+                                viewStore.send(.scopeButtonTapped)
                             }
                         }
                         .padding(.vertical, 5.0)

--- a/routeWidget/Assets.xcassets/AccentColor.colorset/Contents.json
+++ b/routeWidget/Assets.xcassets/AccentColor.colorset/Contents.json
@@ -1,0 +1,11 @@
+{
+  "colors" : [
+    {
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/routeWidget/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/routeWidget/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,13 @@
+{
+  "images" : [
+    {
+      "idiom" : "universal",
+      "platform" : "ios",
+      "size" : "1024x1024"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/routeWidget/Assets.xcassets/Contents.json
+++ b/routeWidget/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/routeWidget/Assets.xcassets/WidgetBackground.colorset/Contents.json
+++ b/routeWidget/Assets.xcassets/WidgetBackground.colorset/Contents.json
@@ -1,0 +1,11 @@
+{
+  "colors" : [
+    {
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/routeWidget/Info.plist
+++ b/routeWidget/Info.plist
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSExtension</key>
+	<dict>
+		<key>NSExtensionPointIdentifier</key>
+		<string>com.apple.widgetkit-extension</string>
+	</dict>
+</dict>
+</plist>

--- a/routeWidget/routeWidget.intentdefinition
+++ b/routeWidget/routeWidget.intentdefinition
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>INEnums</key>
+	<array/>
+	<key>INIntentDefinitionModelVersion</key>
+	<string>1.2</string>
+	<key>INIntentDefinitionNamespace</key>
+	<string>88xZPY</string>
+	<key>INIntentDefinitionSystemVersion</key>
+	<string>20A294</string>
+	<key>INIntentDefinitionToolsBuildVersion</key>
+	<string>12A6144</string>
+	<key>INIntentDefinitionToolsVersion</key>
+	<string>12.0</string>
+	<key>INIntents</key>
+	<array>
+		<dict>
+			<key>INIntentCategory</key>
+			<string>information</string>
+			<key>INIntentDescriptionID</key>
+			<string>tVvJ9c</string>
+			<key>INIntentEligibleForWidgets</key>
+			<true/>
+			<key>INIntentIneligibleForSuggestions</key>
+			<true/>
+			<key>INIntentName</key>
+			<string>Configuration</string>
+			<key>INIntentResponse</key>
+			<dict>
+				<key>INIntentResponseCodes</key>
+				<array>
+					<dict>
+						<key>INIntentResponseCodeName</key>
+						<string>success</string>
+						<key>INIntentResponseCodeSuccess</key>
+						<true/>
+					</dict>
+					<dict>
+						<key>INIntentResponseCodeName</key>
+						<string>failure</string>
+					</dict>
+				</array>
+			</dict>
+			<key>INIntentTitle</key>
+			<string>Configuration</string>
+			<key>INIntentTitleID</key>
+			<string>gpCwrM</string>
+			<key>INIntentType</key>
+			<string>Custom</string>
+			<key>INIntentVerb</key>
+			<string>View</string>
+		</dict>
+	</array>
+	<key>INTypes</key>
+	<array/>
+</dict>
+</plist>

--- a/routeWidget/routeWidget.swift
+++ b/routeWidget/routeWidget.swift
@@ -1,0 +1,69 @@
+//
+//  routeWidget.swift
+//  routeWidget
+//
+//  Created by 이소리 on 2023/09/11.
+//  Copyright © 2023 alom.com. All rights reserved.
+//
+
+import WidgetKit
+import SwiftUI
+import Intents
+
+struct Provider: IntentTimelineProvider {
+    func placeholder(in context: Context) -> SimpleEntry {
+        SimpleEntry(date: Date(), configuration: ConfigurationIntent())
+    }
+
+    func getSnapshot(for configuration: ConfigurationIntent, in context: Context, completion: @escaping (SimpleEntry) -> ()) {
+        let entry = SimpleEntry(date: Date(), configuration: configuration)
+        completion(entry)
+    }
+
+    func getTimeline(for configuration: ConfigurationIntent, in context: Context, completion: @escaping (Timeline<Entry>) -> ()) {
+        var entries: [SimpleEntry] = []
+
+        // Generate a timeline consisting of five entries an hour apart, starting from the current date.
+        let currentDate = Date()
+        for hourOffset in 0 ..< 5 {
+            let entryDate = Calendar.current.date(byAdding: .hour, value: hourOffset, to: currentDate)!
+            let entry = SimpleEntry(date: entryDate, configuration: configuration)
+            entries.append(entry)
+        }
+
+        let timeline = Timeline(entries: entries, policy: .atEnd)
+        completion(timeline)
+    }
+}
+
+struct SimpleEntry: TimelineEntry {
+    let date: Date
+    let configuration: ConfigurationIntent
+}
+
+struct routeWidgetEntryView : View {
+    var entry: Provider.Entry
+
+    var body: some View {
+        Text(entry.date, style: .time)
+    }
+}
+
+struct routeWidget: Widget {
+    let kind: String = "routeWidget"
+
+    var body: some WidgetConfiguration {
+        IntentConfiguration(kind: kind, intent: ConfigurationIntent.self, provider: Provider()) { entry in
+            routeWidgetEntryView(entry: entry)
+        }
+        .configurationDisplayName("My Widget")
+        .description("This is an example widget.")
+    }
+}
+
+struct routeWidget_Previews: PreviewProvider {
+    static var previews: some View {
+        routeWidgetEntryView(entry: SimpleEntry(date: Date(), configuration: ConfigurationIntent()))
+            .previewContext(WidgetPreviewContext(family: .systemSmall))
+    }
+}

--- a/routeWidget/routeWidgetBundle.swift
+++ b/routeWidget/routeWidgetBundle.swift
@@ -1,0 +1,18 @@
+//
+//  routeWidgetBundle.swift
+//  routeWidget
+//
+//  Created by 이소리 on 2023/09/11.
+//  Copyright © 2023 alom.com. All rights reserved.
+//
+
+import WidgetKit
+import SwiftUI
+
+@main
+struct routeWidgetBundle: WidgetBundle {
+    var body: some Widget {
+        routeWidget()
+        routeWidgetLiveActivity()
+    }
+}

--- a/routeWidget/routeWidgetLiveActivity.swift
+++ b/routeWidget/routeWidgetLiveActivity.swift
@@ -1,16 +1,15 @@
 //
-//  routeWidgetLiveActivity.swift
-//  routeWidget
+//  routeLiveActivity.swift
+//  route
 //
-//  Created by 이소리 on 2023/09/11.
-//  Copyright © 2023 alom.com. All rights reserved.
+//  Created by 이소리 on 2023/08/24.
 //
 
 import ActivityKit
 import WidgetKit
 import SwiftUI
 
-struct routeWidgetAttributes: ActivityAttributes {
+struct routeAttributes: ActivityAttributes {
     public struct ContentState: Codable, Hashable {
         // Dynamic stateful properties about your activity go here!
         var value: Int
@@ -18,14 +17,18 @@ struct routeWidgetAttributes: ActivityAttributes {
 
     // Fixed non-changing properties about your activity go here!
     var name: String
+    
 }
 
-struct routeWidgetLiveActivity: Widget {
+struct routeLiveActivity: Widget {
+    @State private var progressValue: Double = 85.0 // 1~99
+    let totalValue: Double = 100.0
+    
     var body: some WidgetConfiguration {
-        ActivityConfiguration(for: routeWidgetAttributes.self) { context in
+        ActivityConfiguration(for: routeAttributes.self) { context in
             // Lock screen/banner UI goes here
             VStack {
-                Text("Hello")
+                Text("view")
             }
             .activityBackgroundTint(Color.cyan)
             .activitySystemActionForegroundColor(Color.black)
@@ -35,19 +38,55 @@ struct routeWidgetLiveActivity: Widget {
                 // Expanded UI goes here.  Compose the expanded UI through
                 // various regions, like leading/trailing/center/bottom
                 DynamicIslandExpandedRegion(.leading) {
-                    Text("Leading")
+                    Text("21:59 도착")
+                        .font(.headline)
                 }
                 DynamicIslandExpandedRegion(.trailing) {
-                    Text("Trailing")
+                    Text("18분 남음")
+                        .font(.headline)
                 }
                 DynamicIslandExpandedRegion(.bottom) {
-                    Text("Bottom")
-                    // more content
+                    VStack(spacing: 0) {
+                        HStack(alignment: .top) {
+                            Image(systemName: "tram")
+                            
+                            Spacer()
+                            
+                            VStack(alignment: .leading) {
+                                HStack {
+                                    Text("어린이대공원역 승차")
+                                        .fontWeight(.bold)
+                                    
+                                    Text("석남(거북시장) 방면")
+                                        .foregroundColor(Color.gray)
+                                        .font(.system(size: 15))
+                                    
+                                    Spacer()
+                                }
+                                Text("빠른환승 1-1")
+                                    .foregroundColor(Color.gray)
+                                    .font(.system(size: 15))
+                                
+                                HStack {
+                                    Text("2분")
+                                        .font(.system(size: 15))
+                                        .foregroundColor(Color.gray)
+                                    
+                                    Text("1개역 이동")
+                                        .fontWeight(.bold)
+                                        .font(.system(size: 15))
+                                }
+                            }
+                        }
+                        ProgressView(value: progressValue, total: totalValue)
+                            .progressViewStyle(humanProgressViewStyle(value: $progressValue, total: .constant(totalValue)))
+                    }
+                    .padding(1.0)
                 }
             } compactLeading: {
-                Text("L")
+                Image(systemName:"tram.fill")
             } compactTrailing: {
-                Text("T")
+                Text("18분 남음")
             } minimal: {
                 Text("Min")
             }
@@ -57,9 +96,32 @@ struct routeWidgetLiveActivity: Widget {
     }
 }
 
-struct routeWidgetLiveActivity_Previews: PreviewProvider {
-    static let attributes = routeWidgetAttributes(name: "Me")
-    static let contentState = routeWidgetAttributes.ContentState(value: 3)
+struct humanProgressViewStyle: ProgressViewStyle {
+    @Binding var value: Double
+    @Binding var total: Double
+    
+    func makeBody(configuration: Configuration) -> some View {
+        
+        let offset = CGFloat(value) / 100
+        return GeometryReader{ geometry in
+            VStack(spacing: 0) {
+                HStack{
+                    Image(systemName: "figure.walk")
+                        .font(.system(size: 15))
+                        .frame(width: CGFloat((geometry.size.width) * offset + 6), alignment: .bottomTrailing) // 6 : 사람이 발을 딱 내딛는 위치
+                    
+                    Spacer()
+                }
+                ProgressView(configuration)
+                    .accentColor(.red)
+            }
+        }
+    }
+}
+
+struct routeLiveActivity_Previews: PreviewProvider {
+    static let attributes = routeAttributes(name: "Me")
+    static let contentState = routeAttributes.ContentState(value: 3)
 
     static var previews: some View {
         attributes

--- a/routeWidget/routeWidgetLiveActivity.swift
+++ b/routeWidget/routeWidgetLiveActivity.swift
@@ -1,0 +1,78 @@
+//
+//  routeWidgetLiveActivity.swift
+//  routeWidget
+//
+//  Created by 이소리 on 2023/09/11.
+//  Copyright © 2023 alom.com. All rights reserved.
+//
+
+import ActivityKit
+import WidgetKit
+import SwiftUI
+
+struct routeWidgetAttributes: ActivityAttributes {
+    public struct ContentState: Codable, Hashable {
+        // Dynamic stateful properties about your activity go here!
+        var value: Int
+    }
+
+    // Fixed non-changing properties about your activity go here!
+    var name: String
+}
+
+struct routeWidgetLiveActivity: Widget {
+    var body: some WidgetConfiguration {
+        ActivityConfiguration(for: routeWidgetAttributes.self) { context in
+            // Lock screen/banner UI goes here
+            VStack {
+                Text("Hello")
+            }
+            .activityBackgroundTint(Color.cyan)
+            .activitySystemActionForegroundColor(Color.black)
+
+        } dynamicIsland: { context in
+            DynamicIsland {
+                // Expanded UI goes here.  Compose the expanded UI through
+                // various regions, like leading/trailing/center/bottom
+                DynamicIslandExpandedRegion(.leading) {
+                    Text("Leading")
+                }
+                DynamicIslandExpandedRegion(.trailing) {
+                    Text("Trailing")
+                }
+                DynamicIslandExpandedRegion(.bottom) {
+                    Text("Bottom")
+                    // more content
+                }
+            } compactLeading: {
+                Text("L")
+            } compactTrailing: {
+                Text("T")
+            } minimal: {
+                Text("Min")
+            }
+            .widgetURL(URL(string: "http://www.apple.com"))
+            .keylineTint(Color.red)
+        }
+    }
+}
+
+struct routeWidgetLiveActivity_Previews: PreviewProvider {
+    static let attributes = routeWidgetAttributes(name: "Me")
+    static let contentState = routeWidgetAttributes.ContentState(value: 3)
+
+    static var previews: some View {
+        attributes
+            .previewContext(contentState, viewKind: .dynamicIsland(.compact))
+            .previewDisplayName("Island Compact")
+        attributes
+            .previewContext(contentState, viewKind: .dynamicIsland(.expanded))
+            .previewDisplayName("Island Expanded")
+        attributes
+            .previewContext(contentState, viewKind: .dynamicIsland(.minimal))
+            .previewDisplayName("Minimal")
+        attributes
+            .previewContext(contentState, viewKind: .content)
+            .previewDisplayName("Notification")
+    }
+}

--- a/routeWidget/routeWidgetLiveActivity.swift
+++ b/routeWidget/routeWidgetLiveActivity.swift
@@ -9,7 +9,7 @@ import ActivityKit
 import WidgetKit
 import SwiftUI
 
-struct routeAttributes: ActivityAttributes {
+struct routeWidgetAttributes: ActivityAttributes {
     public struct ContentState: Codable, Hashable {
         // Dynamic stateful properties about your activity go here!
         var value: Int
@@ -20,12 +20,12 @@ struct routeAttributes: ActivityAttributes {
     
 }
 
-struct routeLiveActivity: Widget {
+struct routeWidgetLiveActivity: Widget {
     @State private var progressValue: Double = 85.0 // 1~99
     let totalValue: Double = 100.0
     
     var body: some WidgetConfiguration {
-        ActivityConfiguration(for: routeAttributes.self) { context in
+        ActivityConfiguration(for: routeWidgetAttributes.self) { context in
             // Lock screen/banner UI goes here
             VStack {
                 Text("view")
@@ -119,9 +119,9 @@ struct humanProgressViewStyle: ProgressViewStyle {
     }
 }
 
-struct routeLiveActivity_Previews: PreviewProvider {
-    static let attributes = routeAttributes(name: "Me")
-    static let contentState = routeAttributes.ContentState(value: 3)
+struct routeWidgetLiveActivity_Previews: PreviewProvider {
+    static let attributes = routeWidgetAttributes(name: "Me")
+    static let contentState = routeWidgetAttributes.ContentState(value: 3)
 
     static var previews: some View {
         attributes


### PR DESCRIPTION
## PR 요약
<!-- 해당 pr에서 작업한 내역을 적어주세요. -->
위젯 ui를 1차적으로 구현하였습니다. 아직 값에 따라 달라지는 뷰는 구현하지 못하였고 보여지는 화면만 구현하였습니다. 
지난 번 pr 피드백들을 수정하였습니다.(피드백 후 해당 브랜치에서 수정하면 피드백을 다시 받고 pr이 반복되는 줄 알아서 바로 수정하지 않았는데, 그렇지 않다는 걸 알게 되어서 이번부터는 바로바로 수정하도록 하겠습니다)

#### 📌 변경 사항
<!-- 변경사항 및 주의 사항 (모듈 설치 등)을 적어주세요. -->
WidgetKit을 추가하였습니다

##### ✅ PR check list
<!-- 피드백 받고 싶거나, 공유할 사항을 적어주세요 -->
1. 프로그레스 바 관련
피그마 디자인을 기반으로 하였는데 실시간 사용자 위치가 어떻게 반영되는지 몰라서 살짝 수정을 해보았습니다. 당시에는 다시 디자인을 부탁드리는 게 죄송해서 제가 해보려고 했는데 오만했던 것 같습니다... 아무튼 나온 디자인은 총 세 개인데요 두 가지 버전입니다.

버전1. 프로그레스바
<img width="410" alt="progressbar사용" src="https://github.com/TEAM-ALOM/finiens-iOS/assets/102736441/9df01df8-58e1-4552-888c-6b7ed7e25656">
깔끔한 느낌이 들지만 경로를 한눈에 파악할 수 없다는 단점이 있습니다.

버전2. 삼색바-(라운드쉐입/스퀘어쉐입, 버스 이미지/번호, 글씨색상)
이미지 ver.
![이미지ver](https://github.com/TEAM-ALOM/finiens-iOS/assets/102736441/398c745b-d96e-4e1d-9546-14ed99a8a40c)
이 버전은 버스 노선을 표시할 때 버스 이미지를 사용합니다.


번호 ver.
![번호ver](https://github.com/TEAM-ALOM/finiens-iOS/assets/102736441/d95c34df-2005-4efe-a04e-4a320cebfaec)
이 버전은 버스 번호를 사용합니다.

삼색바 버전에서는 쉐입을 둥글게 할지, 약간 각지게 할지도 고려해야 할 것 같습니다. (이후에 지하철아이콘은 이미지로 추가할 예정입니다. 이번에는 오류가 나서 추가하지 못했습니다)

위 두가지 중 어느 버전이 나을까요? 다른 의견도 괜찮습니다!

2. 저번 pr에서 Network 파일을 추가했었는데, 지금 이 파일에서는 찾을 수 없었습니다. 혹시 pull이 제대로 되지 않았나 확인해보았는데 그것 빼고는 반영이 잘 되어있는 것 같았어요. Network 파일을 다시 추가해야 할까요!?


#### Linked Issue
<!-- 해결한 이슈 넘버를 붙여주세요. -->
close #45


<!-- PR 요청 전 마지막 확인!
- commit message가 적절한지 확인해주세요. 
- 마지막으로 Coding Convention을 준수했는지 확인해주세요.
- 적절한 branch로 요청했는지 확인해주세요.
- Assignees, Label을 붙여주세요.
- 해결한 이슈를 Link 해주세요.
- PR이 승인된 경우 해당 브랜치는 삭제해주세요.
-->